### PR TITLE
v3.0.1 - color rework, fix windows

### DIFF
--- a/microscopynodes/__init__.py
+++ b/microscopynodes/__init__.py
@@ -65,11 +65,12 @@ def register():
     bpy.types.Scene.MiN_channelList = bpy.props.CollectionProperty(type=ui.channel_list.ChannelDescriptor)
     bpy.types.NODE_MT_add.append(MIN_add_shader_node_menu)
     bpy.types.NODE_MT_context_menu.append(MIN_context_shader_node_menu)
+    prefs = addon_preferences(bpy.context)
     try: 
-        addon_preferences(bpy.context).channels[0].name
+        prefs.channels[0].name
     except:
         try:
-            addon_preferences(bpy.context).n_default_channels = 6
+            prefs.set_channels(bpy.context)
         except AttributeError:
             pass
     return
@@ -83,4 +84,3 @@ def unregister():
             pass
     bpy.types.NODE_MT_add.remove(MIN_add_shader_node_menu)
     bpy.types.NODE_MT_context_menu.remove(MIN_context_shader_node_menu)
-

--- a/microscopynodes/blender_manifest.toml
+++ b/microscopynodes/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "microscopynodes"
-version = "3.0.0"
+version = "3.0.1"
 name = "Microscopy Nodes"
 tagline = "Handling microscopy data in Blender, up to 5D volumes"
 maintainer = "Aafke Gros <aafke.gros@embl.de>"
@@ -27,7 +27,7 @@ copyright =[
 ]
 
 wheels = [
-	"./wheels/aiobotocore-3.5.0-py3-none-any.whl",
+	"./wheels/aiobotocore-3.6.0-py3-none-any.whl",
 	"./wheels/aiohappyeyeballs-2.6.1-py3-none-any.whl",
 	"./wheels/aiohttp-3.13.5-cp313-cp313-macosx_11_0_arm64.whl",
 	"./wheels/aiohttp-3.13.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
@@ -36,7 +36,7 @@ wheels = [
 	"./wheels/aiosignal-1.4.0-py3-none-any.whl",
 	"./wheels/annotated_types-0.7.0-py3-none-any.whl",
 	"./wheels/attrs-26.1.0-py3-none-any.whl",
-	"./wheels/botocore-1.42.91-py3-none-any.whl",
+	"./wheels/botocore-1.43.0-py3-none-any.whl",
 	"./wheels/click-8.3.3-py3-none-any.whl",
 	"./wheels/cloudpickle-3.1.2-py3-none-any.whl",
 	"./wheels/cmap-0.7.1-py3-none-any.whl",
@@ -68,10 +68,10 @@ wheels = [
 	"./wheels/propcache-0.4.1-cp313-cp313-macosx_11_0_arm64.whl",
 	"./wheels/propcache-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
 	"./wheels/propcache-0.4.1-cp313-cp313-win_amd64.whl",
-	"./wheels/pydantic-2.13.3-py3-none-any.whl",
-	"./wheels/pydantic_core-2.46.3-cp313-cp313-macosx_11_0_arm64.whl",
-	"./wheels/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-	"./wheels/pydantic_core-2.46.3-cp313-cp313-win_amd64.whl",
+	"./wheels/pydantic-2.13.4-py3-none-any.whl",
+	"./wheels/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl",
+	"./wheels/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+	"./wheels/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl",
 	"./wheels/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
 	"./wheels/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl",
 	"./wheels/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",

--- a/microscopynodes/data_model.py
+++ b/microscopynodes/data_model.py
@@ -1,10 +1,22 @@
 from typing import Annotated, Optional, Tuple, List, Dict, Any
 from pydantic import BaseModel, Field, field_validator, model_validator, ConfigDict
 import numpy as np
-from cmap import Colormap
+from cmap import Color, Colormap
 from .handle_blender_structs.props import min_keys
 import dask.array as da
 from .io.factories import DataIOFactory
+
+# subtractive space as derived from https://trygvrad.github.io/multivariate-colormaps-for-n-dimensions/ (not a true implementation)
+INIT_COLORS = [
+    Color("#008AE4"),
+    Color("#4A5B00"),
+    Color("#A12352"),
+    Color("#D55800"),
+    Color("#9061D9"),
+    Color("#006C4D"),
+    Color("#CF458F"),
+    Color("#0093AF"),
+]
 
 
 class ChannelDataModel(BaseModel):
@@ -104,12 +116,30 @@ class ChannelDataModel(BaseModel):
 class ChannelVizModel(BaseModel):
     model_config = ConfigDict(json_encoders={Colormap: Colormap.as_dict})
 
-    volume: bool = False
+    ix: int = 0 
+    name: str | None = None
+    volume: bool = True
     surface: bool = False
     labelmask: bool = False
-    emission: bool
-    cmap: Colormap
-    surf_resolution: int
+    emission: bool = True
+    cmap: Colormap | None = None
+    surf_resolution: int = 0
+
+    @model_validator(mode="before")
+    @classmethod
+    def set_ix_defaults(cls, data):
+        if data is None:
+            data = {}
+        if not isinstance(data, dict):
+            return data
+
+        data = data.copy()
+        ix = int(data.get("ix", 0) or 0)
+        if data.get("name") is None:
+            data["name"] = f"Channel {ix}"
+        if data.get("cmap") is None:
+            data["cmap"] = Colormap([INIT_COLORS[ix % len(INIT_COLORS)]])
+        return data
 
     @field_validator("cmap", mode="before")
     def validate_cmap(cls, v):
@@ -119,7 +149,6 @@ class ChannelVizModel(BaseModel):
 
 
 class ChannelModel(BaseModel):
-    name: str
     data: ChannelDataModel
     viz: ChannelVizModel
     cache_path: str
@@ -130,6 +159,10 @@ class ChannelModel(BaseModel):
     @property
     def identifier(self):
         return f"ch_id{self.data.ix}"
+
+    @property
+    def name(self):
+        return self.viz.name
 
 class DatasetModel(BaseModel):
     channels: Annotated[List[ChannelModel], Field(min_length=1)]

--- a/microscopynodes/handle_blender_structs/dependent_props.py
+++ b/microscopynodes/handle_blender_structs/dependent_props.py
@@ -45,17 +45,53 @@ bpy.types.Scene.MiN_channel_nr = IntProperty(
 
 def poll_empty(self, object):
     from ..blender_objects.base import get_min_gn
-    if object.type != 'EMPTY':
+    try:
+        if object is None:
+            return False
+        if object.type != 'EMPTY':
+            return False
+        scene = self if isinstance(self, bpy.types.Scene) else bpy.context.scene
+        if scene.objects.get(object.name) != object:
+            return False
+        if any([get_min_gn(child) != None for child in object.children]):
+            return True
         return False
-    if any([get_min_gn(child) != None for child in object.children]):
-        return True
-    return False
+    except (ReferenceError, AttributeError, TypeError):
+        return False
+
+def valid_reload_object(object, scene=None):
+    try:
+        scene = scene or bpy.context.scene
+        return (
+            object is not None
+            and bpy.data.objects.get(object.name) == object
+            and scene.objects.get(object.name) == object
+            and poll_empty(scene, object)
+        )
+    except (ReferenceError, AttributeError, TypeError):
+        return False
+
+def ensure_valid_reload_object(scene=None):
+    scene = scene or bpy.context.scene
+    try:
+        reload_object = scene.MiN_reload
+    except ReferenceError:
+        scene.MiN_reload = None
+        return None
+    if reload_object is not None and not valid_reload_object(reload_object, scene=scene):
+        scene.MiN_reload = None
+        return None
+    return reload_object
+
+def update_reload(self, context):
+    ensure_valid_reload_object(self)
 
 bpy.types.Scene.MiN_reload = PointerProperty(
         name = "", 
         description = "Reload data of Microscopy Nodes object.\nCan be used to replace deleted (temp) files, change resolution, or channel settings.\nUsage: Point to previously loaded microscopy data.",
         type=bpy.types.Object,
         poll=poll_empty,
+        update=update_reload,
         )
 
 def switch_pixel_size(self, context):

--- a/microscopynodes/handle_blender_structs/props.py
+++ b/microscopynodes/handle_blender_structs/props.py
@@ -120,11 +120,3 @@ bpy.types.Scene.MiN_progress_str = bpy.props.StringProperty(
     description = "current process in load",
     default="",
 )
-
-bpy.types.Scene.MiN_json_preferences = StringProperty(
-    description = 'File path to a .json file that overrides the Microscopy Nodes preferences - use for bpy usage',
-    default = "",
-    subtype = 'FILE_PATH',
-)
-
-

--- a/microscopynodes/load.py
+++ b/microscopynodes/load.py
@@ -43,6 +43,9 @@ class Dataset():
         self.labelmask = None
 
         if holder is not None:
+            from .handle_blender_structs.dependent_props import valid_reload_object
+            holder = holder if valid_reload_object(holder) else None
+        if holder is not None:
             self.initialize_from_previous(holder)
         if dataset_model is not None:
             self.set_state(dataset_model)

--- a/microscopynodes/load.py
+++ b/microscopynodes/load.py
@@ -138,21 +138,21 @@ def set_render_settings():
 
     eevee = getattr(scn, "eevee", None)
     if eevee is not None:
+        volumetric_tile_size = '2' if platform.system() == "Windows" else '1' # windows can be buggy with eevee and large window size
+
         for attr, value in {
-            "volumetric_tile_size": '1',
+            "volumetric_tile_size": volumetric_tile_size,
             "volumetric_end": 300,
             "taa_samples": 64,
         }.items():
             if hasattr(eevee, attr):
                 setattr(eevee, attr, value)
-    # bpy.context.scene.cycles.preview_samples = 8
-    # bpy.context.scene.cycles.samples = 64
+
     scn.view_settings.view_transform = 'Standard'
 
-    scn.cycles.transparent_max_bounces = 40 # less slicing artefacts
-    # bpy.context.scene.cycles.volume_bounces = 32
-    # bpy.context.scene.cycles.volume_max_steps = 16 # less time to render
-    scn.cycles.use_denoising = False # this will introduce noise, but at least also not remove data-noise=
+    scn.cycles.transparent_max_bounces = 40
+    scn.cycles.use_denoising = False
+
     set_viewport_scene_world()
     return
 

--- a/microscopynodes/min_nodes/shader_nodes/cmap_menus.py
+++ b/microscopynodes/min_nodes/shader_nodes/cmap_menus.py
@@ -13,6 +13,9 @@ CMAP_CATEGORIES =  {
     "miscellaneous":"ADD",
     }
 
+def color_names():
+    return sorted(cmap._color.ALL_COLORS)
+
 def cmap_submenu_class(op, opname, category, namespace=None):
     def draw(self, context):
         if self.namespace is None:
@@ -41,6 +44,25 @@ def cmap_submenu_class(op, opname, category, namespace=None):
     )
     return menu_class
 
+def single_color_submenu_class(op, opname):
+    def draw(self, context):
+        for color_name in color_names():
+            op_ = self.layout.operator(op, text=color_name)
+            op_.cmap_name = f"single_color:{color_name}"
+
+    cls_elements = {
+            'bl_idname': single_color_bl(opname)[0],
+            'bl_label': single_color_bl(opname)[1],
+            'draw' : draw
+        }
+
+    menu_class = type(
+        single_color_bl(opname)[0],
+        (bpy.types.Menu,),
+        cls_elements
+    )
+    return menu_class
+
 def cmap_namespaces(categories):
     return list({cmap_name.split(':')[0] for cmap_name in cmap.Catalog().unique_keys(categories=categories, prefer_short_names=False)})
 
@@ -54,6 +76,8 @@ def cmap_bl(category, namespace=None, name=None, opname=None):
         return f"MIN_MT_{category.upper()}_{namespace.upper()}_{opname.upper()}", namespace
     return f"MIN_MT_{category.upper()}_{opname.upper()}", category
 
+def single_color_bl(opname=None):
+    return f"MIN_MT_SINGLE_COLOR_{opname.upper()}", "Single Color"
 
 def cmap_catalog():
     for category in CMAP_CATEGORIES:
@@ -63,13 +87,12 @@ def cmap_catalog():
 def draw_category_menus(self, context, op, opname):
     for category in CMAP_CATEGORIES:
         self.layout.menu(cmap_bl(category, opname=opname)[0], text=cmap_bl(category,opname=opname)[1].capitalize(), icon=CMAP_CATEGORIES[category])
-    op_ = self.layout.operator(op, text="Single Color", icon="MESH_PLANE")
-    op_.cmap_name = 'single_color'
+    self.layout.menu(single_color_bl(opname)[0], text=single_color_bl(opname)[1], icon="MESH_PLANE")
 
 
 CLASSES = []
 for op, opname in [('microscopynodes.add_lut', "ADD"), ('microscopynodes.replace_lut', 'REPLACE')]:
+    CLASSES.append(single_color_submenu_class(op, opname))
     CLASSES = CLASSES + [cmap_submenu_class(op, opname, category) for category in CMAP_CATEGORIES]
     for category in CMAP_CATEGORIES:
         CLASSES.extend([cmap_submenu_class(op, opname, category, namespace) for namespace in cmap_namespaces(categories=category)])
-

--- a/microscopynodes/min_nodes/shader_nodes/handle_cmap.py
+++ b/microscopynodes/min_nodes/shader_nodes/handle_cmap.py
@@ -1,5 +1,5 @@
 import bpy
-from cmap import Colormap
+from cmap import Color, Colormap
 
 
 def set_color_ramp_from_ch(ch, ramp_node):
@@ -20,9 +20,12 @@ def colormap_to_lut(colormap, max_values=32):
 
 
 def get_colormap(name, single_color=(1, 1, 1)):
-    if name.lower() == "single_color":
+    name = name.lower()
+    if name.startswith("single_color:"):
+        return Colormap([Color(name.split(":", 1)[1]).rgba])
+    if name == "single_color":
         return Colormap([[*single_color, 1.0]])
-    return Colormap(name.lower())
+    return Colormap(name)
 
 def set_color_ramp(ramp_node, lut, linear, name):
     from ...ui.preferences import addon_preferences
@@ -50,5 +53,6 @@ def set_color_ramp(ramp_node, lut, linear, name):
             elem.color = tuple(color)
 
     ramp_node.color_ramp.interpolation = "LINEAR" if linear else "CONSTANT"
-    ramp_node.label = name.capitalize()
+    label = name.split(":", 1)[1] if name.startswith("single_color:") else name
+    ramp_node.label = label.capitalize()
     return

--- a/microscopynodes/min_nodes/shader_nodes/handle_cmap.py
+++ b/microscopynodes/min_nodes/shader_nodes/handle_cmap.py
@@ -22,9 +22,9 @@ def colormap_to_lut(colormap, max_values=32):
 def get_colormap(name, single_color=(1, 1, 1)):
     name = name.lower()
     if name.startswith("single_color:"):
-        return Colormap([Color(name.split(":", 1)[1]).rgba])
+        return Colormap([Color(name.split(":", 1)[1])])
     if name == "single_color":
-        return Colormap([[*single_color, 1.0]])
+        return Colormap([Color(tuple(single_color))])
     return Colormap(name)
 
 def set_color_ramp(ramp_node, lut, linear, name):

--- a/microscopynodes/parse_inputs.py
+++ b/microscopynodes/parse_inputs.py
@@ -3,6 +3,7 @@ import numpy as np
 from pathlib import Path
 
 from .handle_blender_structs import *
+from .handle_blender_structs.dependent_props import ensure_valid_reload_object
 from .file_to_array import selected_array_option, channel_data
 from .ui.preferences import addon_preferences
 from .handle_blender_structs.props import min_keys
@@ -12,6 +13,7 @@ from .data_model import DatasetModel, ChannelModel
 
 def parse_blender_ui():
     scn = bpy.context.scene
+    ensure_valid_reload_object(scn)
     if scn.MiN_reload is None:
         scn.MiN_update_data = True
         scn.MiN_update_settings = True

--- a/microscopynodes/parse_inputs.py
+++ b/microscopynodes/parse_inputs.py
@@ -53,22 +53,15 @@ def parse_channellist() -> List[ChannelModel]:
         "frame_end": scn.MiN_load_end_frame,
     }
     for ch_desc in bpy.context.scene.MiN_channelList:
+        viz = ch_desc.to_channelviz()
         channel_models.append(ChannelModel(
-            name=ch_desc.name,
             cache_path=get_cache_dir(),
             data={
                 **shared_data,
-                "ix": ch_desc.ix,
-                "data": channel_data(ch_desc.ix, bpy.context.scene.MiN_axes_order),
+                "ix": viz.ix,
+                "data": channel_data(viz.ix, bpy.context.scene.MiN_axes_order),
             },
-            viz={
-                "volume": ch_desc.volume,
-                "surface": ch_desc.surface,
-                "labelmask": ch_desc.labelmask,
-                "emission": ch_desc.emission,
-                "surf_resolution": addon_preferences(bpy.context).surf_resolution,
-                "cmap": parse_cmap(ch_desc.cmap, ch_desc.single_color),
-            },
+            viz=viz,
         ))
     return channel_models
 
@@ -151,8 +144,3 @@ def parse_relative_loc():
         return [-0.5,-0.5,-0.5] 
     if prefloc == "ZERO":
         return [0, 0, 0] 
-
-
-def parse_cmap(name, single_color):
-    from .min_nodes.shader_nodes.handle_cmap import get_colormap
-    return get_colormap(name, single_color)

--- a/microscopynodes/ui/channel_list.py
+++ b/microscopynodes/ui/channel_list.py
@@ -4,6 +4,38 @@ import os
 
 # from ..min_nodes.shader_nodes import draw_category_menus
 
+CMAP_ITEMS = [
+    ("SINGLE_COLOR", "Single Color","Settable single color, will generate map from black to color" ,"MESH_PLANE", 0),
+    ("VIRIDIS", "Viridis", "bids:viridis","IPO_LINEAR", 1),
+    ("PLASMA", "Plasma","bids:plasma", "IPO_LINEAR", 2),
+    ("COOLWARM", "Coolwarm","matplotlib:coolwarm", "LINCURVE", 3),
+    ("ICEFIRE", "IceFire","seaborn:icefire", "LINCURVE", 4),
+    ("TAB10", "Tab10","seaborn:tab10", "OUTLINER_DATA_POINTCLOUD", 5),
+    ("BRIGHT", "Bright","tol:bright", "OUTLINER_DATA_POINTCLOUD", 6),
+]
+
+CMAP_NAMES = {
+    "SINGLE_COLOR": "single_color",
+    **{item[0]: item[2] for item in CMAP_ITEMS if item[0] != "SINGLE_COLOR"},
+}
+CMAP_ENUMS = {
+    name: item[0]
+    for item in CMAP_ITEMS
+    for name in (item[2].lower(), item[2].split(":")[-1].lower())
+}
+SURF_RESOLUTION_NAMES = {
+    "ACTUAL": 0,
+    "FINE": 1,
+    "MEDIUM": 2,
+    "COARSE": 3,
+}
+
+def surf_resolution_value(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return SURF_RESOLUTION_NAMES.get(str(value).upper(), 0)
+
 def update_ix(self, context):
     context.scene.MiN_ch_index = self.ix
 
@@ -21,24 +53,65 @@ class ChannelDescriptor(bpy.types.PropertyGroup):
     emission : bpy.props.BoolProperty(description="Volume data emits light on load\n(off is recommended for EM)", default=True, update=update_func )
     surface : bpy.props.BoolProperty(description="Load isosurface object.\nAlso useful for binary masks", default=False, update=update_func )
     labelmask : bpy.props.BoolProperty(description="Do not use on regular images.\nLoads separate values in the mask as separate mesh objects", default=False, update=update_func )
+    surf_resolution : bpy.props.IntProperty(default=0, min=0, max=3, update=update_func)
     # -- internal --
-    threshold : bpy.props.FloatProperty(default=-1)
     cmap : bpy.props.EnumProperty(
         name = "Default Colormaps",
-        items=[
-            ("SINGLE_COLOR", "Single Color","Settable single color, will generate map from black to color" ,"MESH_PLANE", 0),
-            ("VIRIDIS", "Viridis", "bids:viridis","IPO_LINEAR", 1),
-            ("PLASMA", "Plasma","bids:plasma", "IPO_LINEAR", 2),
-            ("COOLWARM", "Coolwarm","matplotlib:coolwarm", "LINCURVE", 3),
-            ("ICEFIRE", "IceFire","seaborn:icefire", "LINCURVE", 4),
-            ("TAB10", "Tab10","seaborn:tab10", "OUTLINER_DATA_POINTCLOUD", 5),
-            ("BRIGHT", "Bright","tol:bright", "OUTLINER_DATA_POINTCLOUD", 6),
-        ], 
+        items=CMAP_ITEMS, 
         description= "Colormap for this channel",
         default='SINGLE_COLOR',
         update = update_func 
     )
-    single_color : bpy.props.FloatVectorProperty(subtype="COLOR", min=0, max=1, update= update_func)
+    single_color : bpy.props.FloatVectorProperty(subtype="COLOR_GAMMA", min=0, max=1, update= update_func)
+
+    def to_channelviz(self):
+        from ..data_model import ChannelVizModel
+        from ..min_nodes.shader_nodes.handle_cmap import get_colormap
+
+        return ChannelVizModel(
+            ix=self.ix,
+            name=self.name,
+            volume=self.volume,
+            surface=self.surface,
+            labelmask=self.labelmask,
+            emission=self.emission,
+            surf_resolution=surf_resolution_value(self.surf_resolution),
+            cmap=get_colormap(CMAP_NAMES.get(self.cmap, self.cmap), tuple(self.single_color)),
+        )
+
+    def from_channelviz(self, channelviz):
+        self.ix = channelviz.ix
+        self.name = channelviz.name
+        self.volume = channelviz.volume
+        self.surface = channelviz.surface
+        self.labelmask = channelviz.labelmask
+        self.emission = channelviz.emission
+        self.surf_resolution = surf_resolution_value(channelviz.surf_resolution)
+
+        cmap_data = channelviz.cmap.as_dict()
+        cmap_name = str(cmap_data.get("name", cmap_data.get("identifier", ""))).lower()
+        cmap_enum = CMAP_ENUMS.get(cmap_name) or self._matching_cmap_enum(channelviz)
+        if cmap_enum:
+            self.cmap = cmap_enum
+        else:
+            self.cmap = "SINGLE_COLOR"
+            lut = [color for color in channelviz.cmap.lut(2) if list(color) != [0, 0, 0, 0]]
+            if lut:
+                self.single_color = tuple(lut[-1][:3])
+
+    def _matching_cmap_enum(self, channelviz):
+        from ..min_nodes.shader_nodes.handle_cmap import get_colormap
+
+        target = channelviz.cmap.lut(8).tolist()
+        for enum, cmap_name in CMAP_NAMES.items():
+            if enum == "SINGLE_COLOR":
+                continue
+            try:
+                if get_colormap(cmap_name).lut(8).tolist() == target:
+                    return enum
+            except Exception:
+                pass
+        return None
 
 class SCENE_UL_Channels(UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
@@ -77,18 +150,17 @@ class SCENE_UL_Channels(UIList):
 
 def set_channels(self, context):
     from .preferences import addon_preferences
+    from ..data_model import ChannelVizModel
+
     bpy.context.scene.MiN_channelList.clear()
+    preferences = addon_preferences(bpy.context)
     for ch in range(bpy.context.scene.MiN_channel_nr):
         channel = bpy.context.scene.MiN_channelList.add()
-        default = addon_preferences(bpy.context).channels[ch % len(addon_preferences(bpy.context).channels)]
-        for key in default.keys():
-            try:
-                setattr(channel, key, default[key])
-            except:
-                setattr(channel, key, getattr(default, key))
-        if ch >= len(addon_preferences(bpy.context).channels):
-            channel.name = f"Channel {ch}"
-        channel.ix = ch
+        if ch < len(preferences.channels):
+            viz = preferences.channels[ch].to_channelviz()
+        else:
+            viz = ChannelVizModel(ix=ch)
+        channel.from_channelviz(viz)
         
         
 

--- a/microscopynodes/ui/ops.py
+++ b/microscopynodes/ui/ops.py
@@ -13,6 +13,7 @@ import threading
 from ..data_model import DatasetModel
 from ..load import Scene, Dataset
 from ..parse_inputs import parse_blender_ui
+from ..handle_blender_structs.dependent_props import ensure_valid_reload_object
 
 
 def select_post_load_object(context, dataset, previous_active_obj):
@@ -64,6 +65,7 @@ class TifLoadOperator(bpy.types.Operator):
                     return {"CANCELLED"}
                 context.window_manager.event_timer_remove(self._timer)
                 Scene.from_blender_ui(context)
+                ensure_valid_reload_object(context.scene)
                 dataset = Dataset(holder=context.scene.MiN_reload)
                 dataset.set_state(
                     self.dataset_model,
@@ -119,6 +121,7 @@ class TifLoadBackgroundOperator(bpy.types.Operator):
         if not result["ok"]:
             raise RuntimeError(result["error"])
         Scene.from_blender_ui(context)
+        ensure_valid_reload_object(context.scene)
         dataset = Dataset(holder=context.scene.MiN_reload)
         dataset.set_state(
             dataset_model,

--- a/microscopynodes/ui/panel.py
+++ b/microscopynodes/ui/panel.py
@@ -107,16 +107,6 @@ class TIFLoadPanel(bpy.types.Panel):
         
         box = layout.box()
         row = box.row(align=True)
-        if context.scene.MiN_json_preferences != "":
-            row.label(text=f"Preferences are overriden from {context.scene.MiN_json_preferences}", icon="ERROR")
-            row= box.row()
-            row.prop(bpy.context.scene, 'MiN_json_preferences', text="")
-            row = box.row()
-            row.operator("microscopynodes.reset_json")
-            return
-        
-        
-
         row.label(text="Data Storage:", icon="FILE_FOLDER")
         row.prop(addon_preferences(context), 'cache_option', text="", icon="NONE", emboss=True)
         

--- a/microscopynodes/ui/panel.py
+++ b/microscopynodes/ui/panel.py
@@ -12,7 +12,12 @@ class TIFLoadPanel(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-        scn = bpy.context.scene
+        scn = context.scene
+        try:
+            reload_object = scn.MiN_reload
+        except ReferenceError:
+            reload_object = None
+        reload_object_is_valid = valid_reload_object(reload_object, scene=scn)
 
         col = layout.column(align=True)
         col.label(text=".tif or .zarr:")
@@ -86,7 +91,7 @@ class TIFLoadPanel(bpy.types.Panel):
         row = col.row(align=True)
         row.label(text="", icon='FILE_REFRESH')
         row.prop(bpy.context.scene, 'MiN_reload', icon="OUTLINER_OB_EMPTY")
-        if bpy.context.scene.MiN_reload is not None:
+        if reload_object_is_valid:
             row.prop(bpy.context.scene, 'MiN_update_data', icon="FILE")
             row.prop(bpy.context.scene, 'MiN_update_settings', icon="MATERIAL_DATA")
         
@@ -95,7 +100,7 @@ class TIFLoadPanel(bpy.types.Panel):
         col.separator()
         # col = layout.column(align=False)  
         # row = col.row(align=False)
-        if bpy.context.scene.MiN_reload is None:
+        if not reload_object_is_valid:
             col.operator("microscopynodes.load", text="Load")
         else:
             col.operator("microscopynodes.load", text="Reload")

--- a/microscopynodes/ui/preferences.py
+++ b/microscopynodes/ui/preferences.py
@@ -171,16 +171,34 @@ def addon_preferences(context: bpy.types.Context | None = None):
         print('CANNOT FIND PREFERENCES')
         return None
     
+# subtractive space as derived from https://trygvrad.github.io/multivariate-colormaps-for-n-dimensions/ (not a true implementation)
+# 1 008AE4
+# 2 4A5B00
+# 3 A12352
+# 4 D55800
+# 5 9061D9
+# 6 006C4D
+# 7 CF458F
+# 8 0093AF
 
+# INIT_COLORS = [
+#     (1.0, 1.0, 1.0),
+#     (0/255, 157/255, 224/255),
+#     (224/255, 0/255, 37/255),
+#     (224/255, 214/255, 0/255),
+#     (117/255, 0/255, 224/255),
+#     (0/255, 224/255, 87/255),
+# ]
 
 INIT_COLORS = [
-    (1.0, 1.0, 1.0),
-    (0/255, 157/255, 224/255),
-    (224/255, 0/255, 37/255),
-    (224/255, 214/255, 0/255),
-    (117/255, 0/255, 224/255),
-    (0/255, 224/255, 87/255),
+    (0.0, 0.541, 0.894),
+    (0.290, 0.357, 0.0),
+    (0.631, 0.137, 0.322),
+    (0.835, 0.345, 0.0),
+    (0.565, 0.380, 0.851),
+    (0.0, 0.424, 0.302),
+    (0.812, 0.271, 0.561),
+    (0.0, 0.576, 0.686),
 ]
-
 
 CLASSES = [MicroscopyNodesPreferences, ResetPreferenceJsonOperator]

--- a/microscopynodes/ui/preferences.py
+++ b/microscopynodes/ui/preferences.py
@@ -3,7 +3,7 @@ from .. import __package__
 from bpy.props import StringProperty, BoolProperty, EnumProperty
 from pathlib import Path
 import tempfile
-import json
+from types import SimpleNamespace
 
 
 class MicroscopyNodesPreferences(bpy.types.AddonPreferences):
@@ -11,23 +11,20 @@ class MicroscopyNodesPreferences(bpy.types.AddonPreferences):
     bl_idname = __package__
 
     def set_channels(self, context):
-        while len(addon_preferences(bpy.context).channels)-1 < addon_preferences(bpy.context).n_default_channels:
-            ch = len(addon_preferences(bpy.context).channels)
-            channel = addon_preferences(bpy.context).channels.add()
-            # This instantiates the keys!
-            channel.ix = ch
-            channel.volume = True
-            channel.emission = True
-            channel.surface = False
-            channel.labelmask = False
-            channel.materials = True
-            channel.surf_resolution = 'ACTUAL'
-            channel.threshold=-1
-            channel.cmap='SINGLE_COLOR'
-            channel.name = f"Channel {ch}"
-            channel.single_color = INIT_COLORS[ch % len(INIT_COLORS)]
-        while len(addon_preferences(bpy.context).channels)-1 >= addon_preferences(bpy.context).n_default_channels:
-            addon_preferences(bpy.context).channels.remove(len(addon_preferences(bpy.context).channels)-1)
+        prefs = addon_preferences(bpy.context)
+        while len(prefs.channels)-1 < prefs.n_default_channels:
+            ch = len(prefs.channels)
+            channel = prefs.channels.add()
+            from .data_model import ChannelVizModel
+            from .ui.channel_list import surf_resolution_value
+
+            viz = ChannelVizModel(
+                ix=ch,
+                surf_resolution=surf_resolution_value(prefs.surf_resolution),
+            )
+            channel.from_channelviz(viz)
+        while len(prefs.channels)-1 >= prefs.n_default_channels:
+            prefs.channels.remove(len(prefs.channels)-1)
 
     import_scale_no_unit_spoof : EnumProperty(
         name = 'Microscopy scale -> Blender scale (needs metric pixel unit)',
@@ -54,7 +51,7 @@ class MicroscopyNodesPreferences(bpy.types.AddonPreferences):
         name = 'Defined default channels',
         min= 1,
         max=20,
-        default =6,
+        default =8,
         update=set_channels
     )
     extra_channel_slots : bpy.props.IntProperty(
@@ -115,14 +112,6 @@ class MicroscopyNodesPreferences(bpy.types.AddonPreferences):
     def draw(self, context):
         layout = self.layout
         row = layout.row()
-        if context.scene.MiN_json_preferences != "":
-            row.label(text=f"Preferences are overriden from {context.scene.MiN_json_preferences}", icon="ERROR")
-            row= layout.row()
-            row.prop(bpy.context.scene, 'MiN_json_preferences', text="")
-            row = layout.row()
-            row.operator("microscopynodes.reset_json")
-            return
-        
         row.prop(self, 'cache_path', text='Data storage "Path" default:')
         row = layout.row()
         row.label(text='Data storage "Temporary" default:')
@@ -141,64 +130,40 @@ class MicroscopyNodesPreferences(bpy.types.AddonPreferences):
                         text = 'Overwrite files (debug, does not persist between sessions)', icon_value=0, emboss=True)
 
 
-class ResetPreferenceJsonOperator(bpy.types.Operator):
-    """ Unsets the preference json path """
-    bl_idname ="microscopynodes.reset_json"
-    bl_label = "Use Blender Preferences"
-
-    def execute(self, context):
-        context.scene.MiN_json_preferences = ""
-        return {'FINISHED'}
-
-class DictWithElements:
-    # wraps a dictionary to access elements by dct.element - same method call as addonpreferences
-    def __init__(self, dictionary):
-        self.__dict__ = dictionary
-
-
 def addon_preferences(context: bpy.types.Context | None = None):
+    global DEFAULT_PREFERENCES
     if context is None:
         context = bpy.context
     try:
-        if hasattr(context, 'scene') and context.scene.MiN_json_preferences != "":
-            with open(context.scene.MiN_json_preferences) as stream:
-                return DictWithElements(json.load(stream))
-    except KeyError as e:
-        print(e)
-    try:
         return context.preferences.addons[__package__].preferences
-    except KeyError:
+    except (AttributeError, KeyError):
         print('CANNOT FIND PREFERENCES')
-        return None
+        if DEFAULT_PREFERENCES is None:
+            DEFAULT_PREFERENCES = SimpleNamespace(
+                import_scale="DEFAULT",
+                import_scale_no_unit_spoof="DEFAULT",
+                import_loc="XY_CENTER",
+                surf_resolution="0",
+                invert_color=False,
+                n_default_channels=8,
+                extra_channel_slots=2,
+                cache_option="TEMPORARY",
+                cache_path=str(Path("~", ".microscopynodes").expanduser()),
+                channels=[default_channel(ix) for ix in range(8)],
+            )
+        return DEFAULT_PREFERENCES
+
+
+def default_channel(ix=0):
+    from .data_model import ChannelVizModel
+    viz = ChannelVizModel(ix=ix)
+    return SimpleNamespace(
+        ix=ix,
+        name=viz.name,
+        to_channelviz=lambda: ChannelVizModel(ix=ix),
+    )
+
+
+DEFAULT_PREFERENCES = None
     
-# subtractive space as derived from https://trygvrad.github.io/multivariate-colormaps-for-n-dimensions/ (not a true implementation)
-# 1 008AE4
-# 2 4A5B00
-# 3 A12352
-# 4 D55800
-# 5 9061D9
-# 6 006C4D
-# 7 CF458F
-# 8 0093AF
-
-# INIT_COLORS = [
-#     (1.0, 1.0, 1.0),
-#     (0/255, 157/255, 224/255),
-#     (224/255, 0/255, 37/255),
-#     (224/255, 214/255, 0/255),
-#     (117/255, 0/255, 224/255),
-#     (0/255, 224/255, 87/255),
-# ]
-
-INIT_COLORS = [
-    (0.0, 0.541, 0.894),
-    (0.290, 0.357, 0.0),
-    (0.631, 0.137, 0.322),
-    (0.835, 0.345, 0.0),
-    (0.565, 0.380, 0.851),
-    (0.0, 0.424, 0.302),
-    (0.812, 0.271, 0.561),
-    (0.0, 0.576, 0.686),
-]
-
-CLASSES = [MicroscopyNodesPreferences, ResetPreferenceJsonOperator]
+CLASSES = [MicroscopyNodesPreferences]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microscopynodes"
-version = "3.0.0"
+version = "3.0.1"
 description = "Loading and handling microscopy data in Blender."
 authors = ["Aafke Gros <aafke.gros@embl.de>"]
 include = [

--- a/tests/llm_generated_tests/test_parse_and_model.py
+++ b/tests/llm_generated_tests/test_parse_and_model.py
@@ -1,32 +1,24 @@
-from pathlib import Path
-
 import bpy
 import dask.array as da
 import numpy as np
 import pytest
-import json
 from cmap import Colormap
 
 import microscopynodes
 from microscopynodes.data_model import ChannelModel, DatasetModel
+from microscopynodes.ui.preferences import addon_preferences
 
 from ..utils import prep_load
 
 
 def _set_import_scale(scale_name):
-    pref_path = Path(bpy.context.scene.MiN_json_preferences)
-    with open(pref_path) as f:
-        prefs = json.load(f)
-    prefs["import_scale"] = scale_name
-    with open(pref_path, "w") as f:
-        json.dump(prefs, f)
+    addon_preferences(bpy.context).import_scale = scale_name
 
 
 def _make_channel(name="Channel 0", affine=None):
     if affine is None:
         affine = np.eye(4).tolist()
     return ChannelModel(
-        name=name,
         cache_path="/tmp/example",
         data={
             "dataset_resolution": 0,
@@ -44,6 +36,7 @@ def _make_channel(name="Channel 0", affine=None):
             "emission": True,
             "cmap": Colormap([(1.0, 1.0, 1.0, 1.0)]),
             "surf_resolution": 0,
+            "name": name,
         },
     )
 

--- a/tests/llm_generated_tests/test_structure_invariants.py
+++ b/tests/llm_generated_tests/test_structure_invariants.py
@@ -127,6 +127,54 @@ def test_visibility_socket_matches_channel_visibility():
         assert dataset.volume.gn_mod[socket.identifier] == True
 
 
+def test_parse_clears_reload_when_holder_no_longer_passes_poll():
+    prep_load("5D_5cube")
+    for ch in bpy.context.scene.MiN_channelList:
+        ch["volume"] = True
+        ch["surface"] = False
+        ch["labelmask"] = False
+
+    do_load()
+    holder = bpy.context.scene.MiN_reload
+    assert holder is not None
+
+    for child in list(holder.children):
+        bpy.data.objects.remove(child, do_unlink=True)
+
+    bpy.context.scene.MiN_update_data = False
+    bpy.context.scene.MiN_update_settings = False
+
+    microscopynodes.parse_inputs.parse_blender_ui()
+
+    assert bpy.context.scene.MiN_reload is None
+    assert bpy.context.scene.MiN_update_data is True
+    assert bpy.context.scene.MiN_update_settings is True
+
+
+def test_parse_clears_reload_when_holder_is_unlinked_from_scene():
+    prep_load("5D_5cube")
+    for ch in bpy.context.scene.MiN_channelList:
+        ch["volume"] = True
+        ch["surface"] = False
+        ch["labelmask"] = False
+
+    do_load()
+    holder = bpy.context.scene.MiN_reload
+    assert holder is not None
+
+    for collection in list(holder.users_collection):
+        collection.objects.unlink(holder)
+
+    bpy.context.scene.MiN_update_data = False
+    bpy.context.scene.MiN_update_settings = False
+
+    microscopynodes.parse_inputs.parse_blender_ui()
+
+    assert bpy.context.scene.MiN_reload is None
+    assert bpy.context.scene.MiN_update_data is True
+    assert bpy.context.scene.MiN_update_settings is True
+
+
 def test_surface_affine_translation_offsets_local_mesh_vertices():
     base_mins, base_maxs = _load_single_surface_with_affine_translation((0.0, 0.0, 0.0))
     translated_mins, translated_maxs = _load_single_surface_with_affine_translation((7.0, 11.0, 13.0))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,11 +1,11 @@
 import os
 os.environ["MIN_TEST"] = "1"
 import bpy
-import json
 
 from microscopynodes.handle_blender_structs import *
 from microscopynodes.file_to_array import *
 import microscopynodes
+from microscopynodes.ui.preferences import addon_preferences
 
 import numpy as np
 import pytest
@@ -62,15 +62,15 @@ def prep_load(arrtype=None):
     # microscopynodes._test_register()
     bpy.ops.wm.read_factory_settings(use_empty=True)
 
-
-    pref_template = str(Path(test_folder).parent / "test_preferences_template.json")
-    with open(pref_template) as f: 
-        prefdct = json.load(f)
-    prefdct['cache_path'] = str(test_folder)
-    pref_path = test_folder / 'pref.json'
-    with open(pref_path, 'w') as f: 
-        json.dump(prefdct, f)
-    bpy.context.scene.MiN_json_preferences = str(pref_path)
+    prefs = addon_preferences(bpy.context)
+    prefs.import_scale = "DEFAULT"
+    prefs.import_loc = "XY_CENTER"
+    prefs.surf_resolution = "0"
+    prefs.invert_color = False
+    prefs.cache_option = "TEMPORARY"
+    prefs.cache_path = str(test_folder)
+    if len(prefs.channels) == 0:
+        prefs.set_channels(bpy.context)
 
     if arrtype is None:
         arrtype = '5D_5cube'


### PR DESCRIPTION
- sets eevee resolution lower on windows to have stable viewing
- new default colors based on https://trygvrad.github.io/multivariate-colormaps-for-n-dimensions/
- reworked color and channel viz with the data model
- Replace LUT > Single Color now gives a list of all cmap.Color names